### PR TITLE
Allows Paste in PortableTextEditor

### DIFF
--- a/studio/components/portable-text-editor/PortableTextInput.tsx
+++ b/studio/components/portable-text-editor/PortableTextInput.tsx
@@ -1,0 +1,17 @@
+import {
+  ArrayOfObjectsInputProps,
+  PortableTextInput,
+  type PortableTextInputProps,
+} from 'sanity';
+import {handlePaste} from './utils/handlePaste';
+
+const CustomPortableTextInput = (inputProps: ArrayOfObjectsInputProps) => {
+  return (
+    <PortableTextInput
+      {...(inputProps as unknown as PortableTextInputProps)}
+      onPaste={handlePaste}
+    />
+  );
+};
+
+export default CustomPortableTextInput;

--- a/studio/components/portable-text-editor/utils/cleanWordPaste.ts
+++ b/studio/components/portable-text-editor/utils/cleanWordPaste.ts
@@ -1,0 +1,15 @@
+export function cleanWordPaste(in_word_text: string) {
+  var tmp = document.createElement('DIV');
+  tmp.innerHTML = in_word_text;
+  var newString = tmp.textContent || tmp.innerText;
+  // this next piece converts line breaks into break tags
+  // and removes the seemingly endless crap code
+  newString = newString.replace(/\n\n/g, '<br />').replace(/.*<!--.*-->/g, '');
+  // this next piece removes any break tags (up to 10) at beginning
+  for (let i = 0; i < 10; i++) {
+    if (newString.substring(0, 6) == '<br />') {
+      newString = newString.replace('<br />', '');
+    }
+  }
+  return newString;
+}

--- a/studio/components/portable-text-editor/utils/handlePaste.ts
+++ b/studio/components/portable-text-editor/utils/handlePaste.ts
@@ -1,0 +1,52 @@
+import {TypedObject} from 'sanity';
+import {htmlToBlocks} from '@sanity/block-tools';
+import {type PasteData, type OnPasteFn} from '@sanity/portable-text-editor';
+import {cleanWordPaste} from './cleanWordPaste';
+import plainTextToHtml from './plainTextToHtml';
+
+export const handlePaste: OnPasteFn = (input) => {
+  const {value, event, path, schemaTypes} = input as PasteData;
+
+  const transfer = event.clipboardData;
+
+  // detect what types are available
+  const types = transfer.types;
+
+  // handle Portable Text paste
+  if (types.includes('application/x-portable-text')) {
+    const pText = event.clipboardData.getData('application/x-portable-text');
+    const parsed = JSON.parse(pText) as TypedObject[];
+    return Promise.resolve({
+      insert: parsed,
+    });
+  }
+
+  // handle HTML or Word paste
+  if (types.includes('text/html')) {
+    const html = event.clipboardData.getData('text/html');
+
+    const cleaned = cleanWordPaste(html);
+    // remove head and script tags and whatever makes word paste text as an image
+    const blockContentType = schemaTypes.portableText;
+    let blocks = htmlToBlocks(cleaned, blockContentType) as TypedObject[];
+
+    return Promise.resolve({
+      insert: blocks,
+      path,
+    });
+  }
+  // handle plain text paste
+  if (types.includes('text/plain')) {
+    const plainText = event.clipboardData.getData('text/plain');
+    const plainToHtml = plainTextToHtml(plainText);
+    const blocks = htmlToBlocks(
+      plainToHtml,
+      schemaTypes.portableText,
+    ) as TypedObject[];
+    return Promise.resolve({
+      insert: blocks,
+      path,
+    });
+  }
+  return undefined;
+};

--- a/studio/components/portable-text-editor/utils/plainTextToHtml.ts
+++ b/studio/components/portable-text-editor/utils/plainTextToHtml.ts
@@ -1,0 +1,35 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md. or https://github.com/ckeditor/ckeditor5-clipboard/blob/587c2aac8fe42c4a062db9c69de2b7222f6b693b/LICENSE.md
+ *
+ * @license MPL-2.0; see https://www.mozilla.org/en-US/MPL/2.0/
+ */
+
+/**
+ * Converts plain text to its HTML-ized version.
+ *
+ * @param {String} text The plain text to convert.
+ * @returns {String} HTML generated from the plain text.
+ */
+export default function plainTextToHtml(text: string): string {
+  text = text
+    // Encode <>.
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    // Creates paragraphs for double line breaks and change single line breaks to spaces.
+    // In the future single line breaks may be converted into <br>s.
+    .replace(/\n\n/g, '</p><p>')
+    .replace(/\n/g, ' ')
+    // Preserve trailing spaces (only the first and last one – the rest is handled below).
+    .replace(/^\s/, '&nbsp;')
+    .replace(/\s$/, '&nbsp;')
+    // Preserve other subsequent spaces now.
+    .replace(/\s\s/g, ' &nbsp;');
+
+  if (text.indexOf('</p><p>') > -1) {
+    // If we created paragraphs above, add the trailing ones.
+    text = `<p>${text}</p>`;
+  }
+
+  return text;
+}

--- a/studio/schemas/objects/global/bannerRichtext.tsx
+++ b/studio/schemas/objects/global/bannerRichtext.tsx
@@ -1,6 +1,7 @@
 import {defineArrayMember, defineField} from 'sanity';
 import {internalLinkField} from './headerNavigation';
 import {SquareMousePointer} from 'lucide-react';
+import CustomPortableTextInput from '../../../components/portable-text-editor/PortableTextInput';
 
 export const internalLinkFields = [
   internalLinkField,
@@ -60,4 +61,7 @@ export default defineField({
       },
     }),
   ],
+  components: {
+    input: CustomPortableTextInput,
+  },
 });

--- a/studio/schemas/objects/global/productRichtext.tsx
+++ b/studio/schemas/objects/global/productRichtext.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react';
 import {defineArrayMember, defineField} from 'sanity';
 import {internalLinkFields} from './richtext';
+import CustomPortableTextInput from '../../../components/portable-text-editor/PortableTextInput';
 
 export default defineField({
   name: 'productRichtext',
@@ -134,4 +135,7 @@ export default defineField({
       },
     }),
   ],
+  components: {
+    input: CustomPortableTextInput,
+  },
 });

--- a/studio/schemas/objects/global/richtext.tsx
+++ b/studio/schemas/objects/global/richtext.tsx
@@ -1,6 +1,7 @@
 import {defineArrayMember, defineField} from 'sanity';
 import {internalLinkField} from './headerNavigation';
 import {ExternalLink, Link, SquareMousePointer} from 'lucide-react';
+import CustomPortableTextInput from '../../../components/portable-text-editor/PortableTextInput';
 
 export const internalLinkFields = [
   internalLinkField,
@@ -115,4 +116,7 @@ export default defineField({
       },
     }),
   ],
+  components: {
+    input: CustomPortableTextInput,
+  },
 });


### PR DESCRIPTION
This brings back the Paste functionality for the Portable Text Editor for Firefox.
While https://github.com/sanity-io/sanity/pull/6855 is still pending.