### PR TITLE
Fix dependency issue when running npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-use": "^17.5.1",
-    "sanity": "^3.61.0",
+    "sanity": "^3.62.0",
     "tailwind-merge": "^2.5.4",
     "tiny-invariant": "^1.3.3",
     "vaul": "^1.1.0"

--- a/studio/package.json
+++ b/studio/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^18.3.1",
     "react-is": "^18.3.1",
     "rxjs": "^7.8.1",
-    "sanity": "^3.61.0",
+    "sanity": "^3.62.0",
     "sanity-plugin-internationalized-array": "^3.0.1",
     "sanity-plugin-media": "^2.3.2",
     "styled-components": "^6.1.13"


### PR DESCRIPTION
Related to #369

Update `sanity` version to resolve dependency conflict.

* **package.json**
  - Update `sanity` version to `3.62.0` in `dependencies`.

* **studio/package.json**
  - Update `sanity` version to `3.62.0` in `dependencies`.

