### PR TITLE
Fix MediaGallery to display selected variant images

### DIFF
--- a/app/hooks/useSelectedVariant.tsx
+++ b/app/hooks/useSelectedVariant.tsx
@@ -34,5 +34,8 @@ export function useSelectedVariant(props: {
     return firstAvailableVariant ?? firstVariantFound;
   }
 
-  return selectedVariant;
+  return {
+    ...selectedVariant,
+    images: selectedVariant?.images || [],
+  };
 }


### PR DESCRIPTION
Related to #366

Update `MediaGallery` component to display both product and variant images, prioritizing the selected variant's images.

* Import `useProductVariants` and `useSelectedVariant` hooks in `app/components/product/MediaGallery.tsx`.
* Concatenate variant images with product images and remove duplicate images based on Shopify CDN file URL.
* Modify `useSelectedVariant` hook in `app/hooks/useSelectedVariant.tsx` to include `images` field for the selected variant.

