### PR TITLE
Fix optimizeDeps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       'react-use/esm/useDebounce',
       'react-use/esm/useSessionStorage',
     ],
+    needsInterop: ['@shopify/hydrogen'],
   },
   plugins: [
     hydrogen(),
@@ -49,9 +50,6 @@ export default defineConfig({
        */
       include: [
         'radix-ui',
-        'rxjs',
-        'set-cookie-parser',
-        'cookie',
         'react-router',
         'react-compiler-runtime',
         '@sanity/image-url',


### PR DESCRIPTION
Adds `@shopify/hydrogen` to `optimizeDeps.needsInterop` to fix the `TypeError: Cannot read properties of null (reading 'useContext') at useContext` error on cold start.