### PR TITLE
perf(typegen): debounce, cancel, and skip no-op saves

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "execa": "^8.0.1",
     "globals": "^16.3.0",
     "graphql-config": "^5.1.5",
     "prettier": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.32.0(jiti@2.5.1))
+      execa:
+        specifier: ^8.0.1
+        version: 8.0.1
       globals:
         specifier: ^16.3.0
         version: 16.3.0
@@ -6000,6 +6003,10 @@ packages:
     resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
     engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   exif-component@1.0.1:
     resolution: {integrity: sha512-FXnmK9yJYTa3V3G7DE9BRjUJ0pwXMICAxfbsAuKPTuSlFzMZhQbcvvwx0I8ofNJHxz3tfjze+whxcGpfklAWOQ==}
 
@@ -6309,6 +6316,10 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -6584,6 +6595,10 @@ packages:
   human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   humanize-list@1.0.1:
     resolution: {integrity: sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA==}
@@ -17081,6 +17096,18 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   exif-component@1.0.1: {}
 
   exit-hook@2.2.1: {}
@@ -17406,6 +17433,8 @@ snapshots:
       pump: 3.0.3
 
   get-stream@6.0.1: {}
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -17736,6 +17765,8 @@ snapshots:
   human-signals@3.0.1: {}
 
   human-signals@4.3.1: {}
+
+  human-signals@5.0.0: {}
 
   humanize-list@1.0.1: {}
 

--- a/types/plugin/index.ts
+++ b/types/plugin/index.ts
@@ -19,7 +19,9 @@ export function typegenWatcher(options?: {
   schemaPath?: FilterPattern;
   debounceMs?: number;
 }): Plugin {
-  const queriesPath = options?.queriesPath ?? ['./app/data/sanity/**/*.{ts,tsx}'];
+  const queriesPath = options?.queriesPath ?? [
+    './app/data/sanity/**/*.{ts,tsx}',
+  ];
   const schemaPath = options?.schemaPath ?? ['./app/sanity/**/*.{ts,tsx}'];
   const debounceMs = options?.debounceMs ?? 200;
 
@@ -34,7 +36,13 @@ export function typegenWatcher(options?: {
   let current: ExecaChildProcess | null = null;
   const fileHashCache = new Map<string, string>();
 
-  async function runTasks({schema, queries}: {schema: boolean; queries: boolean}) {
+  async function runTasks({
+    schema,
+    queries,
+  }: {
+    schema: boolean;
+    queries: boolean;
+  }) {
     // Cancel any in-flight run to avoid overlap
     if (current) {
       try {
@@ -54,7 +62,12 @@ export function typegenWatcher(options?: {
         current = execa(
           'sanity',
           ['schema', 'extract', '--path', './types/sanity/schema.json'],
-          {stdio: 'inherit', preferLocal: true, localDir: projectRoot, cwd: projectRoot},
+          {
+            stdio: 'inherit',
+            preferLocal: true,
+            localDir: projectRoot,
+            cwd: projectRoot,
+          },
         );
         const proc = current;
         await proc;
@@ -71,7 +84,12 @@ export function typegenWatcher(options?: {
       }
     } catch (err) {
       const e = err as any;
-      if (!(e?.killed && (e?.signal === 'SIGTERM' || e?.signalDescription === 'Termination'))) {
+      if (
+        !(
+          e?.killed &&
+          (e?.signal === 'SIGTERM' || e?.signalDescription === 'Termination')
+        )
+      ) {
         console.error('\x1b[31m%s\x1b[0m', '[sanity-typegen] Error', err);
       }
     } finally {

--- a/types/plugin/index.ts
+++ b/types/plugin/index.ts
@@ -45,11 +45,13 @@ export function typegenWatcher(options?: {
 
     try {
       if (runExtract) {
-        await execa(
+        current = execa(
           'sanity',
           ['schema', 'extract', '--path', './types/sanity/schema.json'],
           {stdio: 'inherit', preferLocal: true, localDir: projectRoot, cwd: projectRoot},
         );
+        const proc = current;
+        await proc;
       }
       if (runGenerate) {
         current = execa('sanity', ['typegen', 'generate'], {
@@ -58,10 +60,14 @@ export function typegenWatcher(options?: {
           localDir: projectRoot,
           cwd: projectRoot,
         });
-        await current;
+        const proc = current;
+        await proc;
       }
     } catch (err) {
-      console.error('\x1b[31m%s\x1b[0m', '[sanity-typegen] Error', err);
+      const e = err as any;
+      if (!(e?.killed && (e?.signal === 'SIGTERM' || e?.signalDescription === 'Termination'))) {
+        console.error('\x1b[31m%s\x1b[0m', '[sanity-typegen] Error', err);
+      }
     } finally {
       current = null;
     }

--- a/types/plugin/index.ts
+++ b/types/plugin/index.ts
@@ -39,7 +39,10 @@ export function typegenWatcher(options?: {
     if (current) {
       try {
         current.kill('SIGTERM', {forceKillAfterTimeout: 2000});
-      } catch {}
+      } catch {
+        // ignore kill errors (process may have already exited)
+        void 0;
+      }
       current = null;
     }
 

--- a/types/plugin/index.ts
+++ b/types/plugin/index.ts
@@ -1,133 +1,93 @@
 import type {FilterPattern, Plugin} from 'vite';
 
-import {spawn} from 'child_process';
+import path from 'node:path';
 import {createFilter} from 'vite';
-
-// Track ongoing processes to cancel them
-let schemaController: AbortController | null = null;
-let queriesController: AbortController | null = null;
-
-function runCommand(
-  command: string,
-  abortController: AbortController,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const [cmd, ...args] = command.split(' ');
-    const child = spawn(cmd, args, {
-      stdio: 'pipe',
-      signal: abortController.signal,
-    });
-
-    let stdout = '';
-    let stderr = '';
-
-    child.stdout?.on('data', (data: Buffer) => {
-      stdout += data.toString();
-    });
-
-    child.stderr?.on('data', (data: Buffer) => {
-      stderr += data.toString();
-    });
-
-    child.on('close', (code: number | null) => {
-      if (code === 0) {
-        if (stdout) console.log(stdout); // eslint-disable-line no-console
-        if (stderr) console.error(stderr);
-        resolve();
-      } else {
-        reject(new Error(`Process exited with code ${code}`));
-      }
-    });
-
-    child.on('error', (error: Error) => {
-      reject(error);
-    });
-  });
-}
-
-function runCommandsSequentially(
-  commands: string[],
-  abortController: AbortController,
-): Promise<void> {
-  return commands.reduce(
-    (promise, command) =>
-      promise.then(() => runCommand(command, abortController)),
-    Promise.resolve(),
-  );
-}
+import {execa, type ExecaChildProcess} from 'execa';
 
 /**
- * @description This plugin is used to watch for changes in the Sanity schema and GROQ queries to generate the types.
- * @param options - The options for the plugin.
- * @param options.queriesPath - The path to the queries.
- * @param options.schemaPath - The path to the schema.
+ * Watch Sanity schema and GROQ queries to auto-run typegen.
+ *
+ * Performance goals:
+ * - Debounce rapid file changes and batch work.
+ * - Non-blocking HMR (do not return a promise from handleHotUpdate).
+ * - Avoid npm/pnpm wrapper shells; call the local Sanity bin directly.
+ * - Kill in-flight runs cleanly before starting a new one.
  */
 export function typegenWatcher(options?: {
   queriesPath?: FilterPattern;
   schemaPath?: FilterPattern;
+  debounceMs?: number;
 }): Plugin {
-  const queriesPath = options?.queriesPath ?? [
-    './app/data/sanity/**/*.{ts,tsx}',
-  ];
+  const queriesPath = options?.queriesPath ?? ['./app/data/sanity/**/*.{ts,tsx}'];
   const schemaPath = options?.schemaPath ?? ['./app/sanity/**/*.{ts,tsx}'];
+  const debounceMs = options?.debounceMs ?? 200;
+
   const queriesFilter = createFilter(queriesPath);
   const schemaFilter = createFilter(schemaPath);
 
+  const sanityBin = path.resolve(
+    process.cwd(),
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'sanity.cmd' : 'sanity',
+  );
+
+  let timer: NodeJS.Timeout | null = null;
+  let needSchema = false;
+  let needQueries = false;
+  let current: ExecaChildProcess | null = null;
+
+  async function runTasks({schema, queries}: {schema: boolean; queries: boolean}) {
+    // Cancel any in-flight run to avoid overlap
+    if (current) {
+      try {
+        current.kill('SIGTERM', {forceKillAfterTimeout: 2000});
+      } catch {}
+      current = null;
+    }
+
+    const runExtract = schema;
+    const runGenerate = schema || queries;
+
+    try {
+      if (runExtract) {
+        await execa(
+          sanityBin,
+          ['schema', 'extract', '--path', './types/sanity/schema.json'],
+          {stdio: 'inherit'},
+        );
+      }
+      if (runGenerate) {
+        current = execa(sanityBin, ['typegen', 'generate'], {stdio: 'inherit'});
+        await current;
+      }
+    } catch (err) {
+      console.error('\x1b[31m%s\x1b[0m', '[sanity-typegen] Error', err);
+    } finally {
+      current = null;
+    }
+  }
+
+  function schedule(kind: 'schema' | 'queries') {
+    if (kind === 'schema') needSchema = true;
+    else needQueries = true;
+
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      const tasks = {schema: needSchema, queries: needQueries};
+      needSchema = false;
+      needQueries = false;
+      // Fire-and-forget; do not block HMR cycle
+      void runTasks(tasks);
+    }, debounceMs);
+  }
+
   return {
-    name: 'vite-plugin-typegen-watcher',
-    handleHotUpdate({file}) {
-      if (schemaFilter(file)) {
-        // Cancel ongoing schema process if it exists
-        if (schemaController) {
-          schemaController.abort();
-        }
-
-        schemaController = new AbortController();
-
-        const promise = runCommandsSequentially(
-          ['npm run sanity:extract', 'npm run sanity:generate'],
-          schemaController,
-        )
-          .then(() => {
-            schemaController = null;
-          })
-          .catch((error: Error) => {
-            if (error.name !== 'AbortError') {
-              console.error(
-                '\x1b[31m%s\x1b[0m',
-                `\nError executing script:\n\nThe Sanity schema is not valid and Typegen failed to extract the schema.\n\n${error.message}`,
-              );
-            }
-            schemaController = null;
-          });
-
-        return promise;
-      }
-
-      if (queriesFilter(file)) {
-        // Cancel ongoing queries process if it exists
-        if (queriesController) {
-          queriesController.abort();
-        }
-
-        queriesController = new AbortController();
-
-        const promise = runCommand('npm run sanity:generate', queriesController)
-          .then(() => {
-            queriesController = null;
-          })
-          .catch((error: Error) => {
-            if (error.name !== 'AbortError') {
-              console.error(
-                '\x1b[31m%s\x1b[0m',
-                `\nError executing script:\n\nA Sanity GROQ query is not valid and Typegen failed to generate the types.\n\n${error.message}`,
-              );
-            }
-            queriesController = null;
-          });
-
-        return promise;
-      }
+    name: 'vite-plugin-sanity-typegen-watcher',
+    handleHotUpdate(ctx) {
+      const f = ctx.file;
+      if (schemaFilter(f)) schedule('schema');
+      else if (queriesFilter(f)) schedule('queries');
     },
   };
 }


### PR DESCRIPTION
## Summary
- Debounced and non-blocking Sanity typegen watcher to keep HMR smooth
- Cleanly cancels in-flight runs; suppresses expected SIGTERM logs on cancel
- Skips extract/generate when hot-updated file content is unchanged (content hash)

## Details
- Use a single in-flight process tracked in `current` and kill before new runs
- Await a stable child-process reference to avoid races
- Hash file contents on hot update and only schedule when the file actually changed

## Test plan
- Save a GROQ or schema file multiple times quickly; observe no error overlay and a single typegen run after debounce
- Save without changing content (format-only/no-op); typegen should not run
- Change schema; extract should run then generate