### PR TITLE
Add Vercel deployment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules
 .DS_Store
 *.pem
 .vercel
+.vercel/output/
 .env*.local
 
 # Sanity scripts cache

--- a/app/lib/redis-cache.ts
+++ b/app/lib/redis-cache.ts
@@ -1,0 +1,272 @@
+import {Redis} from '@upstash/redis';
+
+interface CachedEntry {
+  body: string; // Base64 encoded
+  status: number;
+  headers: [string, string][];
+  timestamp: number;
+}
+
+interface CacheControlDirectives {
+  maxAge: number;
+  staleWhileRevalidate: number;
+}
+
+function parseCacheControl(header: string | null): CacheControlDirectives {
+  const directives: CacheControlDirectives = {
+    maxAge: 0,
+    staleWhileRevalidate: 0,
+  };
+
+  if (!header) return directives;
+
+  const parts = header.split(',').map((part) => part.trim().toLowerCase());
+
+  for (const part of parts) {
+    const [key, value] = part.split('=');
+    if (key === 'max-age' && value) {
+      directives.maxAge = parseInt(value, 10) || 0;
+    } else if (key === 'stale-while-revalidate' && value) {
+      directives.staleWhileRevalidate = parseInt(value, 10) || 0;
+    }
+  }
+
+  return directives;
+}
+
+function getCacheKey(request: Request): string {
+  return `hydrogen:${request.url}`;
+}
+
+/**
+ * Upstash Redis-based cache implementation for Hydrogen on Vercel.
+ * Implements the Web Cache API interface to match Hydrogen's InMemoryCache behavior.
+ */
+export class UpstashCache implements Cache {
+  private redis: Redis;
+  private debug: boolean;
+
+  constructor(redis: Redis, debug = false) {
+    this.redis = redis;
+    this.debug = debug;
+  }
+
+  private log(message: string) {
+    if (this.debug) {
+      console.log(message);
+    }
+  }
+
+  async match(request: Request): Promise<Response | undefined> {
+    // Only cache GET requests
+    if (request.method !== 'GET') {
+      return undefined;
+    }
+
+    const key = getCacheKey(request);
+
+    try {
+      const cached = await this.redis.get<CachedEntry>(key);
+
+      if (!cached) {
+        this.log(`[UpstashCache] MISS ${request.url}`);
+        return undefined;
+      }
+
+      const {body, status, headers, timestamp} = cached;
+
+      // Parse cache-control from stored headers
+      const cacheControlHeader = headers.find(
+        ([name]) => name.toLowerCase() === 'cache-control',
+      );
+      const {maxAge, staleWhileRevalidate} = parseCacheControl(
+        cacheControlHeader?.[1] || null,
+      );
+
+      const age = Math.floor((Date.now() - timestamp) / 1000);
+      const isStale = age > maxAge;
+      const isExpired = age > maxAge + staleWhileRevalidate;
+
+      if (isExpired) {
+        this.log(`[UpstashCache] EXPIRED ${request.url} (age=${age}s)`);
+        await this.delete(request);
+        return undefined;
+      }
+
+      // Decode the base64 body
+      const bodyBuffer = Uint8Array.from(atob(body), (c) => c.charCodeAt(0));
+
+      // Build response headers, adding cache status
+      const responseHeaders = new Headers(headers);
+      responseHeaders.set('cache', isStale ? 'STALE' : 'HIT');
+      responseHeaders.set('age', String(age));
+
+      this.log(
+        `[UpstashCache] ${isStale ? 'STALE' : 'HIT'} ${request.url} (age=${age}s)`,
+      );
+
+      return new Response(bodyBuffer, {
+        status,
+        headers: responseHeaders,
+      });
+    } catch (error) {
+      console.error('[UpstashCache] match error:', error);
+      return undefined;
+    }
+  }
+
+  async put(request: Request, response: Response): Promise<void> {
+    // Only cache GET requests
+    if (request.method !== 'GET') {
+      return;
+    }
+
+    // Don't cache 206 Partial Content
+    if (response.status === 206) {
+      return;
+    }
+
+    // Don't cache responses with Vary: *
+    const vary = response.headers.get('vary');
+    if (vary === '*') {
+      return;
+    }
+
+    // Parse cache-control to determine TTL
+    const cacheControl = response.headers.get('cache-control');
+    const {maxAge, staleWhileRevalidate} = parseCacheControl(cacheControl);
+
+    // Don't cache if no max-age or zero TTL
+    const totalTtl = maxAge + staleWhileRevalidate;
+    if (totalTtl <= 0) {
+      return;
+    }
+
+    const key = getCacheKey(request);
+
+    try {
+      // Clone response to read body without consuming the original
+      const clonedResponse = response.clone();
+      const bodyArrayBuffer = await clonedResponse.arrayBuffer();
+      const bodyBase64 = btoa(
+        String.fromCharCode(...new Uint8Array(bodyArrayBuffer)),
+      );
+
+      // Serialize headers as array of tuples
+      const headers: [string, string][] = [];
+      response.headers.forEach((value, name) => {
+        headers.push([name, value]);
+      });
+
+      const entry: CachedEntry = {
+        body: bodyBase64,
+        status: response.status,
+        headers,
+        timestamp: Date.now(),
+      };
+
+      // Set with TTL = max-age + stale-while-revalidate
+      await this.redis.set(key, entry, {ex: totalTtl});
+      this.log(
+        `[UpstashCache] PUT ${request.url} (ttl=${totalTtl}s, maxAge=${maxAge}s, swr=${staleWhileRevalidate}s)`,
+      );
+    } catch (error) {
+      console.error('[UpstashCache] put error:', error);
+    }
+  }
+
+  async delete(request: Request): Promise<boolean> {
+    const key = getCacheKey(request);
+
+    try {
+      const deleted = await this.redis.del(key);
+      return deleted > 0;
+    } catch (error) {
+      console.error('[UpstashCache] delete error:', error);
+      return false;
+    }
+  }
+
+  async keys(_request?: Request): Promise<readonly Request[]> {
+    // Note: Full implementation would require SCAN, but this is rarely used.
+    // Return empty array for now as this method is not commonly used by Hydrogen.
+    return [];
+  }
+
+  // Required by Cache interface but not commonly used
+  async add(_request: RequestInfo | URL): Promise<void> {
+    throw new Error('UpstashCache.add() is not implemented');
+  }
+
+  async addAll(_requests: RequestInfo[]): Promise<void> {
+    throw new Error('UpstashCache.addAll() is not implemented');
+  }
+
+  async matchAll(
+    _request?: RequestInfo | URL,
+    _options?: CacheQueryOptions,
+  ): Promise<readonly Response[]> {
+    // Not commonly used by Hydrogen
+    return [];
+  }
+}
+
+/**
+ * A no-op cache implementation for when Redis is not configured.
+ * All operations return empty results, effectively disabling caching.
+ */
+class NoOpCache implements Cache {
+  async match(_request: Request): Promise<Response | undefined> {
+    return undefined;
+  }
+
+  async put(_request: Request, _response: Response): Promise<void> {
+    // No-op
+  }
+
+  async delete(_request: Request): Promise<boolean> {
+    return false;
+  }
+
+  async keys(_request?: Request): Promise<readonly Request[]> {
+    return [];
+  }
+
+  async add(_request: RequestInfo | URL): Promise<void> {
+    // No-op
+  }
+
+  async addAll(_requests: RequestInfo[]): Promise<void> {
+    // No-op
+  }
+
+  async matchAll(
+    _request?: RequestInfo | URL,
+    _options?: CacheQueryOptions,
+  ): Promise<readonly Response[]> {
+    return [];
+  }
+}
+
+interface UpstashCacheOptions {
+  debug?: boolean;
+}
+
+/**
+ * Creates an UpstashCache instance if Redis credentials are configured.
+ * Returns a no-op cache if not configured, so the app still works without caching.
+ */
+export function createUpstashCache(options: UpstashCacheOptions = {}): Cache {
+  const {debug = false} = options;
+
+  try {
+    const redis = Redis.fromEnv();
+    if (debug) {
+      console.log('[UpstashCache] Initialized successfully');
+    }
+    return new UpstashCache(redis, debug);
+  } catch (error) {
+    console.warn('[UpstashCache] Redis not configured. Caching disabled.');
+    return new NoOpCache();
+  }
+}

--- a/lib/hydrogen-vercel/index.ts
+++ b/lib/hydrogen-vercel/index.ts
@@ -1,0 +1,3 @@
+export {vercel} from './vite-plugin';
+export type {VercelPluginOptions} from './vite-plugin';
+export {createSafeSignal, wrapStreamWithCompletion} from './safe-abort';

--- a/lib/hydrogen-vercel/node-adapter.ts
+++ b/lib/hydrogen-vercel/node-adapter.ts
@@ -1,0 +1,94 @@
+/**
+ * Node.js HTTP ↔ Web API bridge for Vercel serverless functions.
+ *
+ * Uses @mjackson/node-fetch-server (by React Router co-creator Michael Jackson)
+ * to convert between Node.js IncomingMessage/ServerResponse and Web-standard
+ * Request/Response objects.
+ */
+import type {IncomingMessage, ServerResponse} from 'node:http';
+import {createRequest, sendResponse} from '@mjackson/node-fetch-server';
+
+/** Options for configuring the Vercel handler. */
+export interface VercelHandlerOptions {
+  /** Enable verbose request logging. @default false */
+  debug?: boolean;
+}
+
+/**
+ * Workers module format with a fetch method.
+ * This is the format used by Cloudflare Workers and mini-oxygen.
+ */
+type WorkersModule = {
+  fetch: (
+    request: Request,
+    env?: unknown,
+    ctx?: unknown,
+  ) => Response | Promise<Response>;
+};
+
+/**
+ * Handler type that accepts both plain functions and Workers modules.
+ */
+type Handler =
+  | ((request: Request) => Response | Promise<Response>)
+  | WorkersModule;
+
+/**
+ * Wraps a Web-standard request handler into a Node.js HTTP handler suitable
+ * for Vercel's serverless function runtime.
+ *
+ * Uses @mjackson/node-fetch-server for efficient Request/Response conversion.
+ * Supports both plain request handlers and Workers module format (objects with
+ * a `fetch` method) for dev/prod parity with mini-oxygen.
+ *
+ * @param handler - A function or Workers module accepting a Web `Request` and returning a `Response`.
+ * @param options - Optional configuration for logging and debugging.
+ * @returns A Node.js-compatible `(req, res) => Promise<void>` handler.
+ */
+export function createVercelHandler(
+  handler: Handler,
+  options?: VercelHandlerOptions,
+): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+  const debug = options?.debug ?? false;
+
+  // Unwrap Workers module format if needed
+  const handleRequest =
+    typeof handler === 'function' ? handler : handler.fetch.bind(handler);
+
+  return async (req, res) => {
+    const startTime = Date.now();
+    const url = req.url || '/';
+
+    if (debug) {
+      console.log(`[hydrogen-vercel] ${req.method} ${url}`);
+    }
+
+    try {
+      // Create Web Request from Node.js IncomingMessage
+      // The package handles AbortController and body streaming automatically
+      const request = createRequest(req, res, {
+        // Vercel's edge network sets these headers for the original client protocol/host
+        // x-forwarded-proto is "https" (no colon), but the package expects "https:"
+        protocol: `${(req.headers['x-forwarded-proto'] as string) || 'https'}:`,
+        host: (req.headers['x-forwarded-host'] as string) || req.headers.host,
+      });
+
+      const response = await handleRequest(request);
+      await sendResponse(res, response);
+
+      if (debug) {
+        console.log(
+          `[hydrogen-vercel] ${response.status} ${url} (${Date.now() - startTime}ms)`,
+        );
+      }
+    } catch (error) {
+      console.error(`[hydrogen-vercel] Error: ${req.method} ${url}`, error);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.end('An unexpected error occurred');
+      } else {
+        res.end();
+      }
+    }
+  };
+}

--- a/lib/hydrogen-vercel/safe-abort.ts
+++ b/lib/hydrogen-vercel/safe-abort.ts
@@ -1,0 +1,65 @@
+/**
+ * Safe abort utilities for streaming SSR on Vercel.
+ * Prevents "Controller is already closed" errors caused by race conditions
+ * between stream completion and request abort signals.
+ */
+
+/**
+ * Creates a safe abort signal that prevents "Controller is already closed" errors.
+ * Forwards abort from the original signal only before stream completion.
+ *
+ * @param requestSignal - The original request.signal from the incoming request
+ * @returns An object with the safe signal and a markComplete callback
+ *
+ * @example
+ * const {signal, markComplete} = createSafeSignal(request.signal);
+ * const body = await renderToReadableStream(<App />, { signal });
+ * const safeBody = wrapStreamWithCompletion(body, markComplete);
+ */
+export function createSafeSignal(requestSignal: AbortSignal) {
+  const controller = new AbortController();
+  let completed = false;
+
+  requestSignal.addEventListener('abort', () => {
+    if (!completed) {
+      controller.abort();
+    }
+  });
+
+  return {
+    signal: controller.signal,
+    markComplete: () => {
+      completed = true;
+    },
+  };
+}
+
+/**
+ * Wraps a ReadableStream to call onComplete when the stream finishes.
+ * Use with createSafeSignal to prevent late abort signals from causing errors.
+ *
+ * @param stream - The response body stream from renderToReadableStream
+ * @param onComplete - Callback to invoke when the stream completes (typically markComplete)
+ * @returns A wrapped ReadableStream that calls onComplete before closing
+ */
+export function wrapStreamWithCompletion(
+  stream: ReadableStream<Uint8Array>,
+  onComplete: () => void,
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader();
+
+  return new ReadableStream({
+    async pull(controller) {
+      const {done, value} = await reader.read();
+      if (done) {
+        onComplete();
+        controller.close();
+        return;
+      }
+      controller.enqueue(value);
+    },
+    cancel() {
+      reader.cancel();
+    },
+  });
+}

--- a/lib/hydrogen-vercel/vite-plugin.ts
+++ b/lib/hydrogen-vercel/vite-plugin.ts
@@ -1,0 +1,202 @@
+import {existsSync} from 'node:fs';
+import {cp, mkdir, rm, writeFile} from 'node:fs/promises';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {Plugin} from 'vite';
+
+const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
+
+/** Configuration options for the hydrogen-vercel Vite plugin. */
+export interface VercelPluginOptions {
+  /** Path to the server entry file, relative to the project root. @default './server.ts' */
+  serverEntry?: string;
+  /** Vercel Functions runtime identifier. @default 'nodejs22.x' */
+  runtime?: string;
+  /** Memory allocation (MB) for the serverless function. */
+  memory?: number;
+  /** Maximum execution time (seconds) for the serverless function. */
+  maxDuration?: number;
+  /** Vercel regions to deploy to (e.g., `['iad1', 'sfo1']`). */
+  regions?: string[];
+  /** Enable response streaming (Vercel Fluid Compute). @default true */
+  streaming?: boolean;
+  /** Enable verbose request logging. @default false */
+  debug?: boolean;
+}
+
+const VIRTUAL_ENTRY_ID = 'virtual:hydrogen-vercel/entry';
+const RESOLVED_VIRTUAL_ENTRY_ID = '\0virtual:hydrogen-vercel/entry';
+
+/**
+ * Creates the Vercel Build Output API v3 route configuration.
+ */
+function createVercelRoutes(assetsDir: string) {
+  return [
+    // Immutable cache for hashed assets
+    {
+      src: `^/${assetsDir}/(.*)$`,
+      headers: {'Cache-Control': 'public, max-age=31536000, immutable'},
+      continue: true,
+    },
+    // Block source maps (security)
+    {src: '^.*\\.map$', status: 404},
+    // Serve static files
+    {handle: 'filesystem'},
+    // Catch-all to serverless function
+    {src: '/(.*)', dest: '/index'},
+  ];
+}
+
+/**
+ * Vite plugin that builds a Hydrogen storefront for Vercel's serverless platform.
+ *
+ * Returns three internal plugins:
+ * - **config** — configures the SSR build (bundling, resolve conditions).
+ * - **entry** — provides a virtual module that wires the user's server entry
+ *   to the Node.js adapter.
+ * - **output** — generates the Vercel Build Output API v3 directory structure
+ *   in `.vercel/output/`.
+ *
+ * In non-SSR builds (the client build), all three plugins are no-ops.
+ */
+export function vercel(options: VercelPluginOptions = {}): Plugin[] {
+  const {
+    serverEntry = './server.ts',
+    runtime = 'nodejs22.x',
+    memory,
+    maxDuration,
+    regions,
+    streaming = true,
+    debug = false,
+  } = options;
+
+  let root: string;
+  let isSsr = false;
+  let assetsDir: string;
+
+  return [
+    {
+      name: 'hydrogen-vercel:config',
+      config(_, {isSsrBuild}) {
+        isSsr = !!isSsrBuild;
+        if (!isSsrBuild) return;
+
+        return {
+          build: {
+            rollupOptions: {
+              input: VIRTUAL_ENTRY_ID,
+              output: {entryFileNames: 'index.js'},
+            },
+          },
+          ssr: {
+            // Bundle all dependencies into a single file for serverless deployment.
+            noExternal: true,
+            resolve: {
+              // Prefer edge/browser condition exports so React uses
+              // renderToReadableStream (streaming SSR) instead of the Node.js
+              // renderToPipeableStream path.
+              conditions: ['workerd', 'worker', 'browser'],
+            },
+          },
+        };
+      },
+      configResolved(config) {
+        root = config.root;
+        assetsDir = config.build.assetsDir;
+
+        // Validate serverEntry exists early to provide a clear error message
+        if (isSsr) {
+          const entryPath = join(config.root, serverEntry);
+          if (!existsSync(entryPath)) {
+            throw new Error(
+              `hydrogen-vercel: serverEntry not found at "${serverEntry}". ` +
+                `Expected file at: ${entryPath}`,
+            );
+          }
+        }
+      },
+    },
+    {
+      name: 'hydrogen-vercel:entry',
+      resolveId(id) {
+        if (id === VIRTUAL_ENTRY_ID) return RESOLVED_VIRTUAL_ENTRY_ID;
+      },
+      load(id) {
+        if (id === RESOLVED_VIRTUAL_ENTRY_ID) {
+          // Generate a virtual entry module that imports the user's server
+          // handler and wraps it with the Node.js adapter.
+          const resolvedServerEntry = join(root, serverEntry).replace(/\\/g, '/');
+          const adapterImportPath = join(PLUGIN_DIR, 'node-adapter.ts').replace(/\\/g, '/');
+          return [
+            `import handler from '${resolvedServerEntry}';`,
+            `import { createVercelHandler } from '${adapterImportPath}';`,
+            `export default createVercelHandler(handler, { debug: ${debug} });`,
+          ].join('\n');
+        }
+      },
+    },
+    {
+      name: 'hydrogen-vercel:output',
+      enforce: 'post',
+      apply: 'build',
+      closeBundle: {
+        sequential: true,
+        order: 'post',
+        async handler() {
+          if (!isSsr) return;
+
+          const dist = join(root, 'dist');
+          const output = join(root, '.vercel/output');
+
+          // Validate build outputs exist
+          if (!existsSync(join(dist, 'server')) || !existsSync(join(dist, 'client'))) {
+            throw new Error(
+              'hydrogen-vercel: dist/server/ or dist/client/ not found. ' +
+                'Ensure both client and server builds complete before this plugin runs.',
+            );
+          }
+
+          // Clean and create output directories
+          await rm(output, {recursive: true, force: true});
+          await mkdir(join(output, 'functions/index.func'), {recursive: true});
+          await mkdir(join(output, 'static'), {recursive: true});
+
+          // Copy build artifacts
+          await cp(join(dist, 'client'), join(output, 'static'), {recursive: true});
+          await cp(join(dist, 'server'), join(output, 'functions/index.func'), {recursive: true});
+
+          // Generate function config
+          const vcConfig: Record<string, unknown> = {
+            runtime,
+            handler: 'index.js',
+            launcherType: 'Nodejs',
+            supportsResponseStreaming: streaming,
+          };
+          if (memory) vcConfig.memory = memory;
+          if (maxDuration) vcConfig.maxDuration = maxDuration;
+          if (regions) vcConfig.regions = regions;
+
+          await writeFile(
+            join(output, 'functions/index.func/.vc-config.json'),
+            JSON.stringify(vcConfig, null, 2),
+          );
+
+          await writeFile(
+            join(output, 'functions/index.func/package.json'),
+            JSON.stringify({type: 'module'}, null, 2),
+          );
+
+          await writeFile(
+            join(output, 'config.json'),
+            JSON.stringify({version: 3, routes: createVercelRoutes(assetsDir)}, null, 2),
+          );
+
+          // Build summary
+          console.log('hydrogen-vercel: Build Output generated at .vercel/output/');
+          console.log(`  - Static assets copied to static/`);
+          console.log(`  - Function: index.func/ (${runtime}${streaming ? ', streaming' : ''})`);
+        },
+      },
+    },
+  ];
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "create:token": "sanity exec app/sanity/scripts/create-viewer-token.ts --with-user-token"
   },
   "dependencies": {
+    "@mjackson/node-fetch-server": "^0.7.0",
     "@portabletext/react": "^6.0.2",
     "@radix-ui/react-icons": "^1.3.2",
     "@sanity/asset-utils": "^2.3.0",
@@ -42,6 +43,8 @@
     "@shopify/polaris": "^13.9.5",
     "@shopify/remix-oxygen": "^3.0.2",
     "@tanem/react-nprogress": "^5.0.56",
+    "@upstash/redis": "^1.36.1",
+    "@vercel/functions": "^3.3.6",
     "@vercel/stega": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "color2k": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@mjackson/node-fetch-server':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@portabletext/react':
         specifier: ^6.0.2
         version: 6.0.2(react@19.2.3)
@@ -71,6 +74,12 @@ importers:
       '@tanem/react-nprogress':
         specifier: ^5.0.56
         version: 5.0.56(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@upstash/redis':
+        specifier: ^1.36.1
+        version: 1.36.1
+      '@vercel/functions':
+        specifier: ^3.3.6
+        version: 3.3.6
       '@vercel/stega':
         specifier: ^1.0.0
         version: 1.0.0
@@ -4865,8 +4874,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@upstash/redis@1.36.1':
+    resolution: {integrity: sha512-N6SjDcgXdOcTAF+7uNoY69o7hCspe9BcA7YjQdxVu5d25avljTwyLaHBW3krWjrP0FfocgMk94qyVtQbeDp39A==}
+
   '@vercel/edge@1.2.2':
     resolution: {integrity: sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==}
+
+  '@vercel/functions@3.3.6':
+    resolution: {integrity: sha512-mLKK3H+v1XjzTiksYN7XV4sl/n8tqb0DeavoUzjFKRQMmx5x+vy1jIl24GY4C8D2dinQPV1ZuCSPhJptBeeE/A==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
 
   '@vercel/stega@1.0.0':
     resolution: {integrity: sha512-jyDUZEBjxmlh28J4y2wB6dBKayYOw1+9fRNRHWRN2oSO+LnooRHUe2z3JeTkCqXY2yrZ9dmtCl982YNIoIBeuw==}
@@ -9124,6 +9149,9 @@ packages:
   unc-path-regex@0.1.2:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -15147,7 +15175,17 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@upstash/redis@1.36.1':
+    dependencies:
+      uncrypto: 0.1.3
+
   '@vercel/edge@1.2.2': {}
+
+  '@vercel/functions@3.3.6':
+    dependencies:
+      '@vercel/oidc': 3.1.0
+
+  '@vercel/oidc@3.1.0': {}
 
   '@vercel/stega@1.0.0': {}
 
@@ -19961,6 +19999,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   unc-path-regex@0.1.2: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
 

--- a/server.ts
+++ b/server.ts
@@ -9,30 +9,7 @@ import {createAppLoadContext} from '~/lib/context';
  */
 function getEnv(env?: Env): Env {
   if (env?.SESSION_SECRET) return env;
-  return {
-    NODE_ENV: process.env.NODE_ENV,
-    SESSION_SECRET: process.env.SESSION_SECRET || '',
-    PUBLIC_STORE_DOMAIN: process.env.PUBLIC_STORE_DOMAIN || '',
-    PUBLIC_CHECKOUT_DOMAIN: process.env.PUBLIC_CHECKOUT_DOMAIN || '',
-    PUBLIC_STOREFRONT_API_TOKEN: process.env.PUBLIC_STOREFRONT_API_TOKEN || '',
-    PUBLIC_STOREFRONT_API_VERSION:
-      process.env.PUBLIC_STOREFRONT_API_VERSION || '',
-    PUBLIC_STOREFRONT_ID: process.env.PUBLIC_STOREFRONT_ID || '',
-    PRIVATE_STOREFRONT_API_TOKEN:
-      process.env.PRIVATE_STOREFRONT_API_TOKEN || '',
-    PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID:
-      process.env.PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID || '',
-    PUBLIC_CUSTOMER_ACCOUNT_API_URL:
-      process.env.PUBLIC_CUSTOMER_ACCOUNT_API_URL || '',
-    PUBLIC_SANITY_STUDIO_PROJECT_ID:
-      process.env.PUBLIC_SANITY_STUDIO_PROJECT_ID || '',
-    PUBLIC_SANITY_STUDIO_DATASET:
-      process.env.PUBLIC_SANITY_STUDIO_DATASET || '',
-    SANITY_STUDIO_USE_PREVIEW_MODE:
-      process.env.SANITY_STUDIO_USE_PREVIEW_MODE || '',
-    SANITY_STUDIO_TOKEN: process.env.SANITY_STUDIO_TOKEN || '',
-    SHOP_ID: process.env.SHOP_ID || '',
-  } as Env;
+  return process.env as unknown as Env;
 }
 
 /**

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,51 @@
 import {storefrontRedirect} from '@shopify/hydrogen';
 import {createRequestHandler} from '@shopify/remix-oxygen';
+import {waitUntil as vercelWaitUntil} from '@vercel/functions';
 import {createAppLoadContext} from '~/lib/context';
+
+/**
+ * Maps process.env to the Env object expected by Hydrogen.
+ * Used on Vercel where env vars come from process.env instead of Workers bindings.
+ */
+function getEnv(env?: Env): Env {
+  if (env?.SESSION_SECRET) return env;
+  return {
+    NODE_ENV: process.env.NODE_ENV,
+    SESSION_SECRET: process.env.SESSION_SECRET || '',
+    PUBLIC_STORE_DOMAIN: process.env.PUBLIC_STORE_DOMAIN || '',
+    PUBLIC_CHECKOUT_DOMAIN: process.env.PUBLIC_CHECKOUT_DOMAIN || '',
+    PUBLIC_STOREFRONT_API_TOKEN: process.env.PUBLIC_STOREFRONT_API_TOKEN || '',
+    PUBLIC_STOREFRONT_API_VERSION:
+      process.env.PUBLIC_STOREFRONT_API_VERSION || '',
+    PUBLIC_STOREFRONT_ID: process.env.PUBLIC_STOREFRONT_ID || '',
+    PRIVATE_STOREFRONT_API_TOKEN:
+      process.env.PRIVATE_STOREFRONT_API_TOKEN || '',
+    PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID:
+      process.env.PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID || '',
+    PUBLIC_CUSTOMER_ACCOUNT_API_URL:
+      process.env.PUBLIC_CUSTOMER_ACCOUNT_API_URL || '',
+    PUBLIC_SANITY_STUDIO_PROJECT_ID:
+      process.env.PUBLIC_SANITY_STUDIO_PROJECT_ID || '',
+    PUBLIC_SANITY_STUDIO_DATASET:
+      process.env.PUBLIC_SANITY_STUDIO_DATASET || '',
+    SANITY_STUDIO_USE_PREVIEW_MODE:
+      process.env.SANITY_STUDIO_USE_PREVIEW_MODE || '',
+    SANITY_STUDIO_TOKEN: process.env.SANITY_STUDIO_TOKEN || '',
+    SHOP_ID: process.env.SHOP_ID || '',
+  } as Env;
+}
+
+/**
+ * Creates an ExecutionContext for Vercel environments.
+ * Uses @vercel/functions waitUntil for background tasks.
+ */
+function getExecutionContext(ctx?: ExecutionContext): ExecutionContext {
+  if (ctx?.waitUntil) return ctx;
+  return {
+    waitUntil: (p: Promise<unknown>) => vercelWaitUntil(p),
+    passThroughOnException: () => {},
+  } as ExecutionContext;
+}
 
 /*
  * Export a fetch handler in module format.
@@ -8,14 +53,17 @@ import {createAppLoadContext} from '~/lib/context';
 export default {
   async fetch(
     request: Request,
-    env: Env,
-    executionContext: ExecutionContext,
+    env?: Env,
+    executionContext?: ExecutionContext,
   ): Promise<Response> {
+    const resolvedEnv = getEnv(env);
+    const resolvedContext = getExecutionContext(executionContext);
+
     try {
       const appLoadContext = await createAppLoadContext(
         request,
-        env,
-        executionContext,
+        resolvedEnv,
+        resolvedContext,
       );
 
       /*

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "pnpm run build",
+  "outputDirectory": ".vercel/output"
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,19 +5,21 @@ import tailwindcss from '@tailwindcss/vite';
 import {defineConfig} from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+import {vercel} from './lib/hydrogen-vercel';
 import {typegenWatcher} from './types/plugin';
 import {sanitySSRFix} from './vite/sanity-ssr-fix';
 
-export default defineConfig({
+export default defineConfig(({command}) => ({
   plugins: [
     sanitySSRFix(),
     hydrogen(),
-    oxygen(),
+    command === 'serve' ? oxygen() : null,
+    vercel(),
     reactRouter(),
     tsconfigPaths(),
     tailwindcss(),
     typegenWatcher(),
-  ],
+  ].filter(Boolean),
   build: {
     assetsInlineLimit: 0,
   },
@@ -68,4 +70,4 @@ export default defineConfig({
       ignored: ['**/types/{sanity,shopify}/**', '**/types/index.ts'],
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary

- Add `hydrogen-vercel` plugin for deploying Hydrogen storefronts to Vercel's serverless platform
- Implement Upstash Redis cache to replace Oxygen's built-in `caches` API
- Support Vercel Fluid Compute with response streaming

## Files Changed

| File | Description |
|------|-------------|
| `lib/hydrogen-vercel/` | Custom Vite plugin + Node.js adapter for Vercel |
| `app/lib/redis-cache.ts` | Upstash Redis cache implementing Web Cache API |
| `app/lib/context.ts` | Fallback to Redis cache when `caches` API unavailable |
| `server.ts` | Adapts env vars and execution context for Vercel |
| `vite.config.ts` | Integrates `vercel()` plugin |
| `vercel.json` | Build output configuration |

## Setup Steps

### 1. Add dependencies

Add the following dependencies to your project:
- `@mjackson/node-fetch-server` - Node.js HTTP adapter
- `@upstash/redis` - Redis client for caching
- `@vercel/functions` - Vercel waitUntil API

### 2. Deploy

Vercel will automatically:
- Run `pnpm run build`
- Output to `.vercel/output/` (Build Output API v3)
- Deploy as a serverless function with streaming enabled

## How It Works

### Build Process
1. Vite builds the client bundle normally
2. For SSR, the `hydrogen-vercel` plugin:
   - Bundles `server.ts` with the Node.js adapter
   - Creates `.vercel/output/functions/index.func/`
   - Copies static assets to `.vercel/output/static/`
   - Generates route configuration in `.vercel/output/config.json`

### Runtime
1. Requests hit Vercel's edge network
2. Static assets served directly with immutable cache headers
3. Dynamic requests routed to the serverless function
4. The Node.js adapter converts Node `IncomingMessage` → Web `Request`
5. Your `server.ts` handles the request using Hydrogen
6. Response streams back to the client (Fluid Compute)

### Caching
- Oxygen: Uses built-in `caches` API (Workers KV)
- Vercel: Falls back to Upstash Redis with same interface
- Both support `stale-while-revalidate` for background refresh

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)